### PR TITLE
fix: Remove sticker ownership indexing from user creation flow

### DIFF
--- a/backend/core/actions/user.py
+++ b/backend/core/actions/user.py
@@ -4,7 +4,6 @@ from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import Session
 
 from core.actions.base import BaseAction
-from core.actions.sticker.external import ExternalStickerAction
 from core.dtos.user import TelegramUserDTO
 from core.models.user import User
 
@@ -26,9 +25,6 @@ class UserAction(BaseAction):
         :param user: The user entity for which the data should be indexed.
         """
         logger.info(f"Indexing user {user.id!r} upon creation...")
-        sticker_action = ExternalStickerAction(self.db_session)
-        sticker_action.index_user_ownership_data(user_id=user.id)
-        logger.info(f"Successfully indexed user {user.id!r} stickers ownership data.")
 
     def create(self, telegram_user: TelegramUserDTO) -> User:
         """


### PR DESCRIPTION
Sticker ownership indexing logic has been removed from the `index_user_creation` method. This simplifies the user creation flow and decouples sticker-related actions, promoting a cleaner separation of concerns.