### PR TITLE
fix: resolve two bugs in refresh_external_sources kick logic

### DIFF
--- a/backend/community_manager/actions/chat.py
+++ b/backend/community_manager/actions/chat.py
@@ -998,6 +998,10 @@ class CommunityManagerTaskChatAction:
                 logger.warning(f"Validation for {source.url!r} failed. Continue...")
                 continue
 
+            # Update content before the eligibility check so that
+            # is_whitelisted reads the current list, not the stale one
+            telegram_chat_external_source_service.set_content(source, diff.current)
+
             if diff.removed:
                 logger.info(
                     f"Found {len(diff.removed)} removed members from the source {source.chat_id!r}"
@@ -1005,13 +1009,11 @@ class CommunityManagerTaskChatAction:
                 users = self.user_service.get_all(telegram_ids=diff.removed)
                 chat_members = self.telegram_chat_user_service.get_all(
                     user_ids=[_user.id for _user in users],
+                    chat_ids=[source.chat_id],
                 )
                 await community_user_action.kick_ineligible_chat_members(
                     chat_members=chat_members
                 )
-            # Set content only after the source was refreshed to ensure
-            # no new attempts to kick users that are already kicked will be made
-            telegram_chat_external_source_service.set_content(source, diff.current)
 
         logger.info("All enabled chat sources refreshed.")
 

--- a/backend/tests/unit/community_manager/actions/test_refresh_external_sources.py
+++ b/backend/tests/unit/community_manager/actions/test_refresh_external_sources.py
@@ -1,0 +1,225 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy.orm import Session
+
+from community_manager.actions.chat import (
+    CommunityManagerTaskChatAction,
+    CommunityManagerUserChatAction,
+)
+from core.actions.authorization import AuthorizationAction
+from core.dtos.chat.rule.whitelist import WhitelistRuleItemsDifferenceDTO
+from core.services.chat.rule.whitelist import TelegramChatExternalSourceService
+from tests.factories.chat import TelegramChatFactory, TelegramChatUserFactory
+from tests.factories.rule.external_source import (
+    TelegramChatWhitelistExternalSourceFactory,
+)
+from tests.factories.rule.group import TelegramChatRuleGroupFactory
+from tests.factories.user import UserFactory
+
+
+@pytest.mark.asyncio
+async def test_refresh_external_sources__removed_user_is_kicked(
+    db_session: Session,
+):
+    chat = TelegramChatFactory.create(is_full_control=True)
+    group = TelegramChatRuleGroupFactory.create(chat=chat)
+
+    user_stays = UserFactory.create(telegram_id=1001)
+    user_removed = UserFactory.create(telegram_id=1002)
+
+    TelegramChatUserFactory.create(chat=chat, user=user_stays, is_managed=True)
+    TelegramChatUserFactory.create(chat=chat, user=user_removed, is_managed=True)
+
+    source = TelegramChatWhitelistExternalSourceFactory.create(
+        chat=chat,
+        group=group,
+        content=[1001, 1002],
+        is_enabled=True,
+        url="https://example.com/api/whitelist",
+    )
+    db_session.flush()
+
+    mock_validate = AsyncMock(
+        return_value=WhitelistRuleItemsDifferenceDTO(
+            previous=[1001, 1002],
+            current=[1001],
+        )
+    )
+
+    action = CommunityManagerTaskChatAction(db_session)
+
+    with patch.object(
+        TelegramChatExternalSourceService,
+        "validate_external_source",
+        mock_validate,
+    ), patch.object(
+        CommunityManagerUserChatAction,
+        "kick_chat_member",
+        new_callable=AsyncMock,
+    ) as mock_kick:
+        await action.refresh_external_sources()
+
+        # User 1002 was removed from the API response and should be kicked
+        assert mock_kick.call_count == 1
+        kicked_member = mock_kick.call_args.args[0]
+        assert kicked_member.user.telegram_id == 1002
+        assert kicked_member.chat_id == chat.id
+
+    db_session.refresh(source)
+    assert source.content == [1001]
+
+
+@pytest.mark.asyncio
+async def test_refresh_external_sources__no_removed_users__no_kicks(
+    db_session: Session,
+):
+    chat = TelegramChatFactory.create(is_full_control=True)
+    group = TelegramChatRuleGroupFactory.create(chat=chat)
+
+    user = UserFactory.create(telegram_id=1001)
+    TelegramChatUserFactory.create(chat=chat, user=user, is_managed=True)
+
+    TelegramChatWhitelistExternalSourceFactory.create(
+        chat=chat,
+        group=group,
+        content=[1001],
+        is_enabled=True,
+        url="https://example.com/api/whitelist",
+    )
+    db_session.flush()
+
+    mock_validate = AsyncMock(
+        return_value=WhitelistRuleItemsDifferenceDTO(
+            previous=[1001],
+            current=[1001],
+        )
+    )
+
+    action = CommunityManagerTaskChatAction(db_session)
+
+    with patch.object(
+        TelegramChatExternalSourceService,
+        "validate_external_source",
+        mock_validate,
+    ), patch.object(
+        CommunityManagerUserChatAction,
+        "kick_chat_member",
+        new_callable=AsyncMock,
+    ) as mock_kick:
+        await action.refresh_external_sources()
+
+        assert mock_kick.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_refresh_external_sources__only_target_chat_affected(
+    db_session: Session,
+):
+    """
+    When a user is removed from Chat A's external source, only Chat A membership
+    should be evaluated — not memberships in other chats.
+    """
+    chat_a = TelegramChatFactory.create(is_full_control=True)
+    chat_b = TelegramChatFactory.create(is_full_control=True)
+    group_a = TelegramChatRuleGroupFactory.create(chat=chat_a)
+
+    user = UserFactory.create(telegram_id=3001)
+
+    TelegramChatUserFactory.create(chat=chat_a, user=user, is_managed=True)
+    TelegramChatUserFactory.create(chat=chat_b, user=user, is_managed=True)
+
+    TelegramChatWhitelistExternalSourceFactory.create(
+        chat=chat_a,
+        group=group_a,
+        content=[3001],
+        is_enabled=True,
+        url="https://example.com/api/a",
+    )
+    db_session.flush()
+
+    mock_validate = AsyncMock(
+        return_value=WhitelistRuleItemsDifferenceDTO(
+            previous=[3001],
+            current=[],
+        )
+    )
+
+    action = CommunityManagerTaskChatAction(db_session)
+
+    with patch.object(
+        TelegramChatExternalSourceService,
+        "validate_external_source",
+        mock_validate,
+    ), patch.object(
+        CommunityManagerUserChatAction,
+        "kick_chat_member",
+        new_callable=AsyncMock,
+    ) as mock_kick:
+        await action.refresh_external_sources()
+
+        kicked_chat_ids = [
+            call.args[0].chat_id
+            for call in mock_kick.call_args_list
+        ]
+
+        # Only Chat A should be affected
+        assert chat_b.id not in kicked_chat_ids
+
+
+@pytest.mark.asyncio
+async def test_refresh_external_sources__content_updated_before_kick(
+    db_session: Session,
+):
+    """
+    set_content must run before kick_ineligible_chat_members so that
+    is_whitelisted reads the current list during the eligibility check.
+    """
+    chat = TelegramChatFactory.create(is_full_control=True)
+    group = TelegramChatRuleGroupFactory.create(chat=chat)
+
+    user = UserFactory.create(telegram_id=4001)
+    TelegramChatUserFactory.create(chat=chat, user=user, is_managed=True)
+
+    source = TelegramChatWhitelistExternalSourceFactory.create(
+        chat=chat,
+        group=group,
+        content=[4001],
+        is_enabled=True,
+        url="https://example.com/api/whitelist",
+    )
+    db_session.flush()
+
+    mock_validate = AsyncMock(
+        return_value=WhitelistRuleItemsDifferenceDTO(
+            previous=[4001],
+            current=[],
+        )
+    )
+
+    action = CommunityManagerTaskChatAction(db_session)
+
+    with patch.object(
+        TelegramChatExternalSourceService,
+        "validate_external_source",
+        mock_validate,
+    ):
+        # Verify that content is updated before eligibility check reads it
+        auth_action = AuthorizationAction(db_session)
+
+        original_get_ineligible = auth_action.get_ineligible_chat_members
+
+        def assert_content_updated_before_check(chat_members):
+            # At this point, set_content should have already run
+            db_session.refresh(source)
+            assert 4001 not in (source.content or []), (
+                "set_content must run before get_ineligible_chat_members"
+            )
+            return original_get_ineligible(chat_members=chat_members)
+
+        with patch.object(
+            AuthorizationAction,
+            "get_ineligible_chat_members",
+            side_effect=assert_content_updated_before_check,
+        ):
+            await action.refresh_external_sources()


### PR DESCRIPTION
## Description

Fixes two bugs in `refresh_external_sources` that prevent users from being kicked when they are removed from an external API whitelist.

**Bug 1 — Stale `rule.content` during eligibility check:**  
`set_content` was called *after* `kick_ineligible_chat_members`. The eligibility check inside the kick path reads `rule.content` from the DB, which still contains the old list (including the removed user). So `is_whitelisted` returns `True`, the user appears eligible, and `kick_chat_member` is never called. After that, `set_content` updates the DB — and the next cycle sees no diff, so the user is never kicked.

**Bug 2 — Missing `chat_id` filter:**  
`telegram_chat_user_service.get_all(user_ids=...)` was called without a `chat_ids` filter, returning user memberships across *all* chats. This caused the eligibility check to run for unrelated chats, potentially kicking users from chats that had nothing to do with the external source change.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I ran all tests and they passed successfully.
- [x] I reviewed my own code and followed the project's code style.
- [x] I included relevant details in the PR description or commit messages.

## Changes

- **Move `set_content` before kick block:** Content is updated before the eligibility check runs, so `is_whitelisted` reads the current list. If a kick fails mid-way, the periodic compliance check (`check_chat_members_compliance`) will catch the user on the next run.
- **Add `chat_ids=[source.chat_id]` filter:** Only the membership in the target chat is evaluated and potentially kicked.
- **Add 4 unit tests:** Covering the fixed behavior — removed user is kicked, no diff means no kicks, only the target chat is affected, and content is updated before the eligibility check.

## How Has This Been Tested?

Unit tests added in `tests/unit/community_manager/actions/test_refresh_external_sources.py`:
- `test_refresh_external_sources__removed_user_is_kicked`
- `test_refresh_external_sources__no_removed_users__no_kicks`
- `test_refresh_external_sources__only_target_chat_affected`
- `test_refresh_external_sources__content_updated_before_kick`

Run with:
```
make test
# or specifically:
MODE=test ./docker.sh run --rm -it test pytest tests/unit/community_manager/actions/test_refresh_external_sources.py -v
```

## Additional Notes

Existing users who should have been kicked but weren't (due to Bug 1) can be cleaned up by running `check-target-chat-members` for each chat with external source rules — the updated `rule.content` already excludes them, so the compliance check will correctly identify them as ineligible.