### PR TITLE
fix(cli): repair load_wallets_on_start import after indexer rename

### DIFF
--- a/backend/core/src/core/cli/load_wallets_on_start.py
+++ b/backend/core/src/core/cli/load_wallets_on_start.py
@@ -7,7 +7,7 @@ from core.constants import DEFAULT_WALLET_TRACK_EXPIRATION
 from core.services.db import DBService
 from core.services.superredis import RedisService
 from core.services.wallet import WalletService
-from indexer.tasks import fetch_wallet_details
+from indexer_blockchain.tasks import fetch_wallet_details
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- `core/cli/load_wallets_on_start.py` imports `indexer.tasks`, which no longer exists — the package was split into `indexer_blockchain` / `indexer_gifts` / `indexer_price` / `indexer_stickers` and this CLI was missed.
- `python -m core.cli.load_wallets_on_start` raises `ModuleNotFoundError: No module named 'indexer'` on import, before any DB read or Redis write happens.
- This breaks the only in-tree recovery path for the external wallet-tracking Redis (`REDIS_TRANSACTION_DB`). After any loss of that DB (volume reset, `FLUSHDB`, OOM before `BGSAVE`, etc.) tracked wallets cannot be re-seeded from the database, and `transaction-lookup` stops emitting `noticed_wallets` events for the affected addresses — leading to stale on-chain ownership in the local DB and members not being kicked when they no longer meet eligibility rules.

## Fix
One-line rename of the import:

```diff
-from indexer.tasks import fetch_wallet_details
+from indexer_blockchain.tasks import fetch_wallet_details
```

## Test plan
- [x] Built `Dockerfile.indexer-blockchain` against this branch.
- [x] `python -c "from core.cli.load_wallets_on_start import load_wallets_on_start"` resolves successfully inside the container (was failing with `ModuleNotFoundError` on `main`).