### PR TITLE
fix(api): stop awaiting sync delete for jetton and nft rules

### DIFF
--- a/backend/api/routes/admin/chat/rule/jetton.py
+++ b/backend/api/routes/admin/chat/rule/jetton.py
@@ -83,4 +83,4 @@ async def delete_chat_jetton_rule(
         requestor=request.state.user,
         chat_slug=slug,
     )
-    await action.delete(rule_id=rule_id)
+    action.delete(rule_id=rule_id)

--- a/backend/api/routes/admin/chat/rule/nft.py
+++ b/backend/api/routes/admin/chat/rule/nft.py
@@ -85,4 +85,4 @@ async def delete_chat_nft_collection_rule(
         requestor=request.state.user,
         chat_slug=slug,
     )
-    await action.delete(rule_id=rule_id)
+    action.delete(rule_id=rule_id)


### PR DESCRIPTION
## Summary
DELETE on jetton-rule and NFT-collection-rule admin routes is **completely broken on `main`** — every request returns HTTP 500 and the rule does not get removed via the API.

## Root cause
`backend/api/routes/admin/chat/rule/jetton.py:86` and `backend/api/routes/admin/chat/rule/nft.py:88` do:

```python
await action.delete(rule_id=rule_id)
```

But the corresponding action methods (`core/actions/chat/rule/blockchain.py:293` for NFT, `:476` for jetton) are plain synchronous functions:

```python
def delete(self, rule_id: int) -> None:
    ...
```

They return `None`. `await None` raises `TypeError: object NoneType can't be used in 'await' expression`, which FastAPI converts into HTTP 500.

Reproduced inside the `Dockerfile.api` image:

```
$ python ...
--- buggy (main) ---
TypeError (this is the 500 in API): object NoneType can't be used in 'await' expression
--- fixed (this branch) ---
OK: returned cleanly
```

## Fix
Two-line change — drop `await` so the sync method is called normally:

```diff
-    await action.delete(rule_id=rule_id)
+    action.delete(rule_id=rule_id)
```

(applied in both `jetton.py` and `nft.py`)

## Test plan
- [x] Built `Dockerfile.api` against this branch.
- [x] Reproduced `TypeError` on `main` and verified clean execution after the fix using a minimal repro that mirrors the route handler logic with a stub action.
- [ ] Manual: hit `DELETE /admin/chat/{slug}/rule/jetton/{rule_id}` and `DELETE /admin/chat/{slug}/rule/nft/{rule_id}` against a deployed instance and confirm 2xx response and that the rule is removed.